### PR TITLE
Remove references to dockerfile-coq

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ scripts are:
 - `dockerfile-opam`: installs OPAM and OCaml switches
 - `dockerfile-archive`: builds an OPAM source package archive and HTTP server
 - `dockerfile-core`: builds the Jane Street Core library suite
-- `dockerfile-coq`: builds the Coq compiler and adds its OPAM remote
 - `dockerfile-bulk`: constructs the OPAM bulk build scripts
 
 ## Docker Repostories

--- a/docker-scripts.install
+++ b/docker-scripts.install
@@ -1,7 +1,7 @@
 bin: [
-  "dockerfile-ocaml.ml" { "dockerfile-ocaml" }
-  "dockerfile-opam.ml"  { "dockerfile-opam" }
-  "dockerfile-core.ml"  { "dockerfile-core" }
-  "dockerfile-coq.ml"   { "dockerfile-coq" }
-  "dockerfile-bulk.ml"  { "dockerfile-bulk" }
+  "dockerfile-ocaml.ml"   { "dockerfile-ocaml" }
+  "dockerfile-opam.ml"    { "dockerfile-opam" }
+  "dockerfile-core.ml"    { "dockerfile-core" }
+  "dockerfile-archive.ml" { "dockerfile-archive" }
+  "dockerfile-bulk.ml"    { "dockerfile-bulk" }
 ]


### PR DESCRIPTION
Pinning currently fails, but succeeds with this change.